### PR TITLE
Update cosmwasm-examples tag

### DIFF
--- a/smart-contracts/downloading-and-compiling-smart-contracts.md
+++ b/smart-contracts/downloading-and-compiling-smart-contracts.md
@@ -13,8 +13,8 @@ Let's download the repo in which we collect [`cosmwasm-examples` \(opens new win
 git clone https://github.com/CosmWasm/cosmwasm-examples
 cd cosmwasm-examples
 git fetch
-git checkout escrow-0.7.0
-cd escrow
+git checkout escrow-0.10.0
+cd contracts/escrow
 
 # compile the wasm contract with stable toolchain
 rustup default stable


### PR DESCRIPTION
In lucina testnet , I have this error: 
```
$ junod tx wasm store .....
Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: 
Error calling the VM: Error during static Wasm validation: Wasm contract doesn't have required export: "interface_version_5".
Exports required by VM: ["interface_version_5", "instantiate", "allocate", "deallocate"]. 
Contract version too old for this VM?: create wasm contract failed: invalid request
```