### PR TITLE
Update setting-up-cosmovisor.md with buffer size fix

### DIFF
--- a/validators/setting-up-cosmovisor.md
+++ b/validators/setting-up-cosmovisor.md
@@ -137,6 +137,7 @@ Environment="DAEMON_NAME=junod"
 Environment="DAEMON_HOME=/home/<your-user>/.juno"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+Environment="DAEMON_LOG_BUFFER_SIZE=512"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add buffer size increase to prevent cosmovisor from freezing when large log outputs are passed from junod. This is a known issue when cw contracts are interacted with.