### PR TITLE
Validators: Adding chrony as pre-req for time synchronization

### DIFF
--- a/validators/getting-setup.md
+++ b/validators/getting-setup.md
@@ -18,11 +18,8 @@ If you have chosen a different operating system, you will need to modify your co
 # update the local package list and install any available upgrades
 sudo apt-get update && sudo apt upgrade -y
 
-# install toolchain 
-sudo apt-get install make build-essential gcc git jq -y
-
-# ensure accurate time synchronization for node
-sudo apt-get install chrony -y
+# install toolchain and ensure accurate time synchronization
+sudo apt-get install make build-essential gcc git jq chrony -y
 ```
 
 ## Install Go


### PR DESCRIPTION
Fixes CosmosContracts/juno#67

- Per conversation, recommending to add `chrony` as a node pre-req for validators.
- Removed extra spaces to align to markdown requirements.