### PR TITLE
gh-21 use `--output json` and update jq invocations in sc tutorials

### DIFF
--- a/smart-contracts/tutorial-cw1/download-compile-store.md
+++ b/smart-contracts/tutorial-cw1/download-compile-store.md
@@ -45,6 +45,6 @@ Also like last time, look in the JSON output for the `code_id` value. If you wou
 
 ```bash
 cd artifacts
-RES=$(junod tx wasm store cw1_subkeys.wasm  --from <your-key> --chain-id=<chain-id> --gas auto -y)
-CODE_ID=$(echo $RES | jq -r '.logs[0].events[0].attributes[-1].value')
+TX=$(junod tx wasm store cw1_subkeys.wasm  --from <your-key> --chain-id=<chain-id> --gas auto --output json -y | jq -r '.txhash')
+CODE_ID=$(junod query tx $TX --output json | jq -r '.logs[0].events[-1].attributes[0].value')
 ```

--- a/smart-contracts/tutorial-erc-20/compile.md
+++ b/smart-contracts/tutorial-erc-20/compile.md
@@ -57,8 +57,8 @@ Alternatively, you can capture the output of the command run above, by doing the
 
 ```bash
 cd artifacts
-RES=$(junod tx wasm store cw_erc20.wasm  --from <your-key> --chain-id=<chain-id> --gas auto -y)
-CODE_ID=$(echo $RES | jq -r '.logs[0].events[0].attributes[-1].value')
+TX=$(junod tx wasm store cw_erc20.wasm  --from <your-key> --chain-id=<chain-id> --gas auto --output json -y | jq -r '.txhash')
+CODE_ID=$(junod query tx $TX --output json | jq -r '.logs[0].events[-1].attributes[0].value')
 ```
 
 You can now see this value with:

--- a/smart-contracts/tutorial-erc-20/initialise.md
+++ b/smart-contracts/tutorial-erc-20/initialise.md
@@ -58,7 +58,7 @@ junod tx wasm instantiate $CODE_ID \
 If this succeeds, look in the output and get contract address from output e.g `juno1a2b....` or run:
 
 ```bash
-CONTRACT_ADDR=$(junod query wasm list-contract-by-code $CODE_ID | jq -r '.[0].address')
+CONTRACT_ADDR=$(junod query wasm list-contract-by-code $CODE_ID --output json | jq -r '.contracts[0]')
 ```
 
 This will allow you to query using the value of `$CONTRACT_ADDR`
@@ -66,4 +66,3 @@ This will allow you to query using the value of `$CONTRACT_ADDR`
 ```bash
 junod query wasm contract $CONTRACT_ADDR
 ```
-


### PR DESCRIPTION
The default output for `junod wasm` commands seems to be yaml now so we need to specify that we'd like json for parsing with `jq`. Also updates the parsing code to reflect the current layout of responses.