### PR TITLE
Added font used

### DIFF
--- a/juno/brand-identity.md
+++ b/juno/brand-identity.md
@@ -36,3 +36,7 @@ Secondary Color: 9f9f9f
 Secondary Color: ffffff
 
 ![](../.gitbook/assets/juno-secondary-color-white-.png)
+
+**Font**
+
+The wordmark font is Gotham Medium.


### PR DESCRIPTION
After a long mystery it is now known what font is used for the Juno assets thanks to CamelJuno!

The font used is `Gotham Medium` and added this to the 'Brand Identity' page.