### PR TITLE
Added Stake&Relax in relayer list

### DIFF
--- a/juno/juno-developers.md
+++ b/juno/juno-developers.md
@@ -138,4 +138,6 @@ Cosmos Spaces [https://twitter.com/Cosmos\_spaces](https://twitter.com/Cosmos\_s
 
 ChainTools [https://twitter.com/ChaintoolsT](https://twitter.com/ChaintoolsT)
 
+Stake&Relax [https://linktr.ee/stakeandrelax](https://linktr.ee/stakeandrelax)
+
 The list is constantly expanding. If your name is not mentioned and your actively contributing please reach out to the core team.


### PR DESCRIPTION
We are actively relaying JUNO to/from: Bitsong, Persistence, Akash, Secret and Emoney. More chains will follow! juno1qx6nnykvn390su7hrtunvdj509khadeh0q92w6