### PR TITLE
Minor doc updates: v9.0.0 » v10.0.2

### DIFF
--- a/smart-contracts-and-junod-development/junod-local-dev-setup.md
+++ b/smart-contracts-and-junod-development/junod-local-dev-setup.md
@@ -78,7 +78,7 @@ To call Juno inside a container, use `docker exec` like so:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.6
+  cosmwasm/rust-optimizer:0.12.8
 
 # copy wasm to container
 docker cp artifacts/your_compiled.wasm juno_node_1:/your_compiled.wasm

--- a/smart-contracts-and-junod-development/junod-local-dev-setup.md
+++ b/smart-contracts-and-junod-development/junod-local-dev-setup.md
@@ -46,7 +46,7 @@ docker run -it \
   -p 26657:26657 \
   -e STAKE_TOKEN=ujunox \
   -e UNSAFE_CORS=true \
-  ghcr.io/cosmoscontracts/juno:v9.0.0 \
+  ghcr.io/cosmoscontracts/juno:v10.0.2 \
   ./setup_and_run.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
 ```
 

--- a/validators/getting-setup.md
+++ b/validators/getting-setup.md
@@ -69,10 +69,10 @@ git checkout <version-tag>
 The `<version-tag>` will need to be set to either a [testnet `chain-id`](joining-the-testnets.md#current-testnets) or the latest [mainnet version tag](joining-mainnet.md).
 
 {% hint style="warning" %}
-For genesis (Phoenix 2), the mainnet genesis version tag will be `v9.0.0` - i.e:
+For genesis (Phoenix 2), the mainnet genesis version tag will be `v10.0.2` - i.e:
 
 ```bash
-git checkout v9.0.0
+git checkout v10.0.2
 ```
 {% endhint %}
 
@@ -88,5 +88,5 @@ To confirm that the installation has succeeded, you can run:
 ```bash
 junod version
 
-# v9.0.0
+# v10.0.2
 ```

--- a/validators/joining-mainnet.md
+++ b/validators/joining-mainnet.md
@@ -18,7 +18,7 @@ The Juno Network has undergone several upgrades since the network inception on O
 
 The second is the current mainnet "Juno Phoenix 2" which raised Juno from the ashes on July 28th 2022.
 
-The correct version of the binary for mainnet at genesis (Phoenix) is `v9.0.0`. Its release page can be found [here](https://github.com/CosmosContracts/juno/releases/tag/v9.0.0).
+The correct version of the binary for mainnet at genesis (Phoenix) is `v10.0.2`. Its release page can be found [here](https://github.com/CosmosContracts/juno/releases/tag/v10.0.2).
 
 {% hint style="info" %}
 To find the current version of the binary, go to the [mainnet repo](https://github.com/cosmoscontracts/mainnet) and find the most recent upgrade.

--- a/validators/mainnet-upgrades.md
+++ b/validators/mainnet-upgrades.md
@@ -45,4 +45,4 @@ Block height at Phoenix genesis is **4136532**.
 
 #### V10
 
-An upgrade to V10 of Juno happened at block [5004269](https://www.mintscan.io/juno/blocks/5004269), up to version `v10.0.2` of Juno.
+An upgrade to V10 of Juno happened at block [5004269](https://www.mintscan.io/juno/blocks/5004269), up to version [v10.0.2](https://github.com/CosmosContracts/juno/releases/tag/v10.0.2) of Juno.


### PR DESCRIPTION
During HackWasm I saw my `junod` misbehaving until I updated to `v10.0.2`, so I wanted to update the places in the docs that mentioned checking out the old tag.