### PR TITLE
Add helpful message regarding cosmovisor automatic downloads

### DIFF
--- a/validators/setting-up-cosmovisor.md
+++ b/validators/setting-up-cosmovisor.md
@@ -32,7 +32,7 @@ go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
 ```
 
 {% hint style="danger" %}
-When using cosmovisor, make sure that you do not have auto download of binaries on.
+When using cosmovisor, make sure that you do not have auto download of binaries on. Ensure you have the environment variable `DAEMON_ALLOW_DOWNLOAD_BINARIES` set to `false`.
 {% endhint %}
 
 Your installation can be confirmed with:


### PR DESCRIPTION
Earlier, when I was reading through the docs, I wasn't sure how to make sure my Cosmovisor wasn't gonna automatically download binaries. We have a warning here, but not a solution, so I thought I'd add the environment variable to change, which is `DAEMON_ALLOW_DOWNLOAD_BINARIES=false`.