### PR TITLE
Update Api Endpoints for Juno Testnet

### DIFF
--- a/developer-guides/api-endpoints/README.md
+++ b/developer-guides/api-endpoints/README.md
@@ -5,6 +5,6 @@ description: Schema for Juno node interaction (GET and POST requests).
 # API Endpoints
 
 Mainnet: [https://cosmos.directory/juno/nodes](https://cosmos.directory/juno/nodes)\
-Testnet: [https://testnet.cosmos.directory/junotestnet/nodes](https://cosmos.directory/juno/nodes)
+Testnet: [https://testnet.cosmos.directory/junotestnet/nodes](https://testnet.cosmos.directory/junotestnet/nodes)
 
 Click on the "Nodes" tab, then "REST" for publicly provided infrastructure. If you wish to run your own non rate limited node, [check out our guide here](../../validators/joining-mainnet/)


### PR DESCRIPTION
Fix the testnet link for the cosmos.directory to https://testnet.cosmos.directory/junotestnet/nodes which was wrongly directed with https://cosmos.directory/juno/nodes.